### PR TITLE
Refactor unneeded plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ $ npm install --save-dev @tailify/postcss-preset
 To get started, add this to your `postcss.config.js` file:
 
 ```js
-module.exports = {
-  plugins: [require('@tailify/postcss-preset')]
-};
+module.exports = require('@tailify/postcss-preset');
 ```
 
 [build-status-image]: https://travis-ci.com/tailify/postcss-preset.svg?branch=master

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,28 +1,24 @@
 'use strict';
 
-const postcss = require('postcss');
-
-const isDevelopment = process.env.NODE_ENV !== 'production';
-
-module.exports = postcss.plugin('@tailify/postcss-preset', () => (root, result) => {
-  const { processor } = result;
-
-  processor.use(
-    require('postcss-preset-env')({
-      features: {
-        'all-property': true,
-        'break-properties': true,
-        'custom-properties': true,
-        'font-variant-property': true,
-        'gap-properties': true,
-        'grid-layout': true,
-        'media-query-ranges': true,
-      },
-      stage: false,
-    })
-  );
-
-  if (!isDevelopment) {
-    processor.use(require('cssnano'));
-  }
-});
+module.exports = ({ env }) => {
+  return {
+    plugins: [
+      require('postcss-preset-env')({
+        features: {
+          'all-property': true,
+          'break-properties': true,
+          'custom-properties': true,
+          'font-variant-property': true,
+          'gap-properties': true,
+          'grid-layout': true,
+          'media-query-ranges': true,
+        },
+        stage: false,
+      }),
+      env === 'production' &&
+        require('cssnano')({
+          preset: 'default',
+        }),
+    ].filter(Boolean),
+  };
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
     "eslint": "^5.10.0",
     "jest": "^24.7.0",
     "postcss": "^7.0.0",
+    "postcss-load-config": "^2.0.0",
     "prettier": "^1.15.0"
+  },
+  "peerDependencies": {
+    "postcss": "^7.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should minify when building for production 1`] = `"@media (min-width:768px){body{background-color:red}}"`;
+
 exports[`should not contain invalid rules 1`] = `
-"@media (min-width: 768px) {}
+"
+@media (min-width: 768px) {
+  body {
+    background-color: red;
+  }
+}
 "
 `;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,12 +1,28 @@
 'use strict';
 
 const postcss = require('postcss');
-const processor = postcss([require('./../lib/index.js')]);
+const postcssrc = require('postcss-load-config');
 
-const source = '@media (width >= 768px) {}\n';
+const source = `
+@media (width >= 768px) {
+  body {
+    background-color: red;
+  }
+}
+`;
 
 test('should not contain invalid rules', async () => {
+  const config = await postcssrc({}, './lib', { configPath: './lib/index.js' });
+  const processor = postcss(config);
+
   const result = await processor.process(source, { from: 'foo/bar.css' });
-  expect(result).toBeTruthy();
+  expect(result.css).toMatchSnapshot();
+});
+
+test('should minify when building for production', async () => {
+  const config = await postcssrc({ env: 'production' }, './lib', { configPath: './lib/index.js' });
+  const processor = postcss(config);
+
+  const result = await processor.process(source, { from: 'foo/bar.css' });
   expect(result.css).toMatchSnapshot();
 });


### PR DESCRIPTION
We don't need to create a postcss plugin to set up our presets. This means we don't need to include postcss as a dependency.

As part of this PR I've also fixed cssnano so it actually runs 🙈